### PR TITLE
Adding usart devices support

### DIFF
--- a/dts/sample.dts
+++ b/dts/sample.dts
@@ -88,7 +88,31 @@
 };
 
 
+&usart3 {
+        status = "okay";
+        pinctrl-0 = <&usart3_tx>, <&usart3_rx>;
+		sentry,owner = <0xC001F002>;
+        sentry,label = <0x103>;
+		usart,peripheral-clock = <40>; /* 40MHz APB1 clock */
+};
+
 &pinctrl {
+	usart3_tx: usart3_tx {
+		id = "usart3_tx";
+		pinmux = <&gpioc 10 STM32_DT_PIN_MODE_ALTFUNC(7)>;
+		pincfg = <STM32_OTYPER_PUSH_PULL \
+			  STM32_OSPEEDR_VERY_HIGH_SPEED \
+			  STM32_PUPDR_NO_PULL>;
+	};
+
+	usart3_rx: usart3_rx {
+		id = "usart3_rx";
+		pinmux = <&gpioc 11 STM32_DT_PIN_MODE_ALTFUNC(7)>;
+		pincfg = <STM32_OTYPER_PUSH_PULL \
+			  STM32_OSPEEDR_VERY_HIGH_SPEED \
+			  STM32_PUPDR_NO_PULL>;
+	};
+
     i2c1_scl_pb8: i2c_scl_pb8 {
 			id = "i2c1_scl";
             pinmux = <&gpiob 8 STM32_DT_PIN_MODE_ALTFUNC(4)>;

--- a/examples/i2c/i2c_bus_driver/i2c_bus_driver.c
+++ b/examples/i2c/i2c_bus_driver/i2c_bus_driver.c
@@ -439,8 +439,6 @@ static void stm32_i2c_bus_acknowledge_irq(uint32_t IRQn)
 	if (clear_flags != 0U) {
 		stm32_i2c_bus_clear_flags(clear_flags);
 	}
-	/* Now that ISR handling for this device is complete, acknowledge the IRQ */
-	merlin_platform_acknowledge_irq(&my_i2c_driver, IRQn);
 
 }
 

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -3,3 +3,4 @@
 
 subdir('i2c')
 subdir('usb')
+subdir('usart')

--- a/examples/usart/meson.build
+++ b/examples/usart/meson.build
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 H2Lab Development Team
+
+libdrvusart = static_library('drvusart',
+    sources: [
+        'stm32_usart_driver.c',
+        'stm32_usart_driver.h',
+    ],
+    include_directories: include_directories('.'),
+    dependencies: [ merlin_dep ],
+)
+
+drvusart_dep = declare_dependency(
+    link_with: libdrvusart,
+    include_directories: include_directories('.'),
+)

--- a/examples/usart/stm32_usart_driver.c
+++ b/examples/usart/stm32_usart_driver.c
@@ -1,0 +1,688 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 H2Lab Development Team
+
+/*
+ * Generic STM32 USART/UART bus driver example for the Merlin platform.
+ *
+ * Compatible with the USART IP block present in all STM32 product families
+ * (F0/F1/F2/F3/F4/F7/G0/G4/H5/H7/L0/L4/U5/WB/WL …).  The register layout
+ * is identical across these families (USART_CR1, USART_CR2, USART_CR3,
+ * USART_BRR, USART_ISR, USART_ICR, USART_RDR, USART_TDR).
+ *
+ * The driver supports up to STM32_USART_MAX_INSTANCES controllers
+ * simultaneously.  Each instance is identified by its DTS label; all public
+ * functions take that label as first argument so a single task can drive
+ * several USART/UART peripherals at the same time.
+ *
+ * Operation is intentionally limited to polled mode so that the essential
+ * Merlin platform interactions are easy to follow.
+ */
+
+#include <inttypes.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <merlin/buses/usart.h>
+#include <merlin/io.h>
+#include "stm32_usart_driver.h"
+
+/* -------------------------------------------------------------------------
+ * STM32 USART/UART register offsets
+ * Identical across F0/F1/F2/F3/F4/F7/G0/G4/H5/H7/L0/L4/U5/WB series.
+ * ---------------------------------------------------------------------- */
+#define USART_CR1_OFFSET    0x00UL
+#define USART_CR2_OFFSET    0x04UL
+#define USART_CR3_OFFSET    0x08UL
+#define USART_BRR_OFFSET    0x0CUL
+#define USART_ISR_OFFSET    0x1CUL
+#define USART_ICR_OFFSET    0x20UL
+#define USART_RDR_OFFSET    0x24UL
+#define USART_TDR_OFFSET    0x28UL
+
+/* CR1 bits */
+#define USART_CR1_UE        (1UL << 0)   /**< USART enable */
+#define USART_CR1_RE        (1UL << 2)   /**< Receiver enable */
+#define USART_CR1_TE        (1UL << 3)   /**< Transmitter enable */
+#define USART_CR1_RXNEIE    (1UL << 5)   /**< RXNE interrupt enable */
+#define USART_CR1_TXEIE     (1UL << 7)   /**< TXE interrupt enable */
+#define USART_CR1_PCE       (1UL << 10)  /**< Parity control enable */
+#define USART_CR1_PS        (1UL << 9)   /**< Parity selection: 0=even, 1=odd */
+#define USART_CR1_M0        (1UL << 12)  /**< Word length bit 0 */
+#define USART_CR1_M1        (1UL << 28)  /**< Word length bit 1 */
+#define USART_CR1_OVER8     (1UL << 15)  /**< Oversampling by 8 */
+
+/* CR2 bits */
+#define USART_CR2_STOP_SHIFT    12U
+#define USART_CR2_STOP_MASK     (0x3UL << USART_CR2_STOP_SHIFT)
+#define USART_CR2_STOP_1        (0x0UL << USART_CR2_STOP_SHIFT)
+#define USART_CR2_STOP_0_5      (0x1UL << USART_CR2_STOP_SHIFT)
+#define USART_CR2_STOP_2        (0x2UL << USART_CR2_STOP_SHIFT)
+#define USART_CR2_STOP_1_5      (0x3UL << USART_CR2_STOP_SHIFT)
+#define USART_CR2_CLKEN         (1UL << 11) /**< Clock enable (synchronous mode) */
+
+/* CR3 bits */
+#define USART_CR3_RTSE      (1UL << 8)  /**< RTS enable */
+#define USART_CR3_CTSE      (1UL << 9)  /**< CTS enable */
+
+/* ISR bits */
+#define USART_ISR_RXNE      (1UL << 5)  /**< Read data register not empty */
+#define USART_ISR_TC        (1UL << 6)  /**< Transmission complete */
+#define USART_ISR_TXE       (1UL << 7)  /**< Transmit data register empty */
+#define USART_ISR_ORE       (1UL << 3)  /**< Overrun error */
+#define USART_ISR_NE        (1UL << 2)  /**< Noise error */
+#define USART_ISR_FE        (1UL << 1)  /**< Framing error */
+#define USART_ISR_PE        (1UL << 0)  /**< Parity error */
+
+/* ICR bits */
+#define USART_ICR_ORECF     (1UL << 3)
+#define USART_ICR_NECF      (1UL << 2)
+#define USART_ICR_FECF      (1UL << 1)
+#define USART_ICR_PECF      (1UL << 0)
+#define USART_ICR_TCCF      (1UL << 6)
+
+#define USART_ERROR_MASK    (USART_ISR_ORE | USART_ISR_NE | USART_ISR_FE | USART_ISR_PE)
+#define USART_ERROR_CLR     (USART_ICR_ORECF | USART_ICR_NECF | USART_ICR_FECF | USART_ICR_PECF)
+
+#define USART_POLL_RETRIES  10000U
+
+static int stm32_usart_fops_configure(struct usart_driver *self,
+                                      const struct usart_config *config);
+static int stm32_usart_fops_write(struct usart_driver *self,
+                                  const uint8_t *wrbuf, size_t len);
+static int stm32_usart_fops_read(struct usart_driver *self,
+                                 uint8_t *rdbuf, size_t len);
+static int stm32_usart_fops_flush(struct usart_driver *self);
+
+static int stm32_usart_isr(void *self, uint32_t IRQn);
+
+/*
+ * Each slot is initialised at probe time. All instances share the same
+ * fops table since the STM32 USART/UART IP is register-compatible across
+ * all families.
+ */
+static struct usart_bus_fops g_usart_fops = {
+    .configure = stm32_usart_fops_configure,
+    .write     = stm32_usart_fops_write,
+    .read      = stm32_usart_fops_read,
+    .flush     = stm32_usart_fops_flush,
+};
+
+static struct usart_driver g_usart_instances[STM32_USART_MAX_INSTANCES];
+static bool g_usart_slot_used[STM32_USART_MAX_INSTANCES];
+
+/**
+ * @brief Look up an active USART instance by DTS label.
+ * @param label DTS label used at probe time.
+ * @return Pointer to the matching instance, or NULL when not found.
+ */
+static struct usart_driver *stm32_usart_instance_get(uint32_t label)
+{
+    for (size_t i = 0U; i < STM32_USART_MAX_INSTANCES; i++) {
+        if (g_usart_slot_used[i] &&
+            g_usart_instances[i].platform.label == label) {
+            return &g_usart_instances[i];
+        }
+    }
+    return NULL;
+}
+
+/**
+ * @brief Allocate and initialise a free USART instance slot.
+ * @return Pointer to an initialised slot, or NULL when all slots are used.
+ */
+static struct usart_driver *stm32_usart_instance_alloc(void)
+{
+    for (size_t i = 0U; i < STM32_USART_MAX_INSTANCES; i++) {
+        if (!g_usart_slot_used[i]) {
+            struct usart_driver *drv = &g_usart_instances[i];
+
+            drv->fops                       = &g_usart_fops;
+            drv->platform.devh              = 0;
+            drv->platform.label             = 0UL;
+            drv->platform.devinfo           = NULL;
+            drv->platform.name              = "stm32 usart/uart driver";
+            drv->platform.compatible        = "st,stm32-usart";
+            drv->platform.driver_fops       = &g_usart_fops;
+            drv->platform.platform_fops.isr = stm32_usart_isr;
+            drv->platform.type              = DEVICE_TYPE_USART;
+            drv->private_data               = NULL;
+
+            g_usart_slot_used[i] = true;
+            return drv;
+        }
+    }
+    return NULL;
+}
+
+/**
+ * @brief Release an allocated USART instance slot.
+ * @param drv Instance pointer previously returned by the allocator.
+ */
+static void stm32_usart_instance_free(struct usart_driver *drv)
+{
+    for (size_t i = 0U; i < STM32_USART_MAX_INSTANCES; i++) {
+        if (&g_usart_instances[i] == drv) {
+            g_usart_slot_used[i] = false;
+            return;
+        }
+    }
+}
+
+/**
+ * @brief Compute the absolute register address for an instance.
+ * @param drv USART instance.
+ * @param offset Register offset from peripheral base.
+ * @return Absolute memory-mapped register address.
+ */
+static inline size_t usart_reg(const struct usart_driver *drv, size_t offset)
+{
+    return ((size_t)drv->platform.devinfo->baseaddr + offset);
+}
+
+/**
+ * @brief Read a 32-bit USART register.
+ * @param drv USART instance.
+ * @param offset Register offset from peripheral base.
+ * @return 32-bit register value.
+ */
+static inline uint32_t usart_read32(const struct usart_driver *drv,
+                                    size_t offset)
+{
+    return merlin_ioread32(usart_reg(drv, offset));
+}
+
+/**
+ * @brief Write a 32-bit USART register.
+ * @param drv USART instance.
+ * @param offset Register offset from peripheral base.
+ * @param value Value to write.
+ */
+static inline void usart_write32(const struct usart_driver *drv,
+                                 size_t offset, uint32_t value)
+{
+    merlin_iowrite32(usart_reg(drv, offset), value);
+}
+
+/**
+ * @brief Check whether a USART instance is mapped and ready.
+ * @param drv USART instance.
+ * @return true when mapped and device metadata is available, false otherwise.
+ */
+static inline bool usart_is_ready(const struct usart_driver *drv)
+{
+    return (drv->platform.devh != 0) && (drv->platform.devinfo != NULL);
+}
+
+/**
+ * @brief Disable USART peripheral.
+ * @param drv USART instance.
+ */
+static void stm32_usart_disable(struct usart_driver *drv)
+{
+    uint32_t cr1 = usart_read32(drv, USART_CR1_OFFSET);
+    cr1 &= ~USART_CR1_UE;
+    usart_write32(drv, USART_CR1_OFFSET, cr1);
+}
+
+/**
+ * @brief Enable USART peripheral.
+ * @param drv USART instance.
+ */
+static void stm32_usart_enable(struct usart_driver *drv)
+{
+    uint32_t cr1 = usart_read32(drv, USART_CR1_OFFSET);
+    cr1 |= USART_CR1_UE;
+    usart_write32(drv, USART_CR1_OFFSET, cr1);
+}
+
+/**
+ * @brief Wait until TX data register is empty.
+ * @param drv USART instance.
+ * @return 0 on success, -1 on timeout.
+ */
+static int stm32_usart_wait_txe(struct usart_driver *drv)
+{
+    if (merlin_iopoll32_until_set(usart_reg(drv, USART_ISR_OFFSET),
+                                  USART_ISR_TXE,
+                                  USART_POLL_RETRIES) != STATUS_OK) {
+        return -1;
+    }
+    return 0;
+}
+
+/**
+ * @brief Wait until RX data register contains a byte.
+ * @param drv USART instance.
+ * @return 0 on success, -1 on timeout.
+ */
+static int stm32_usart_wait_rxne(struct usart_driver *drv)
+{
+    if (merlin_iopoll32_until_set(usart_reg(drv, USART_ISR_OFFSET),
+                                  USART_ISR_RXNE,
+                                  USART_POLL_RETRIES) != STATUS_OK) {
+        return -1;
+    }
+    return 0;
+}
+
+/**
+ * @brief Wait until transmission is fully complete.
+ * @param drv USART instance.
+ * @return 0 on success, -1 on timeout.
+ */
+static int stm32_usart_wait_tc(struct usart_driver *drv)
+{
+    if (merlin_iopoll32_until_set(usart_reg(drv, USART_ISR_OFFSET),
+                                  USART_ISR_TC,
+                                  USART_POLL_RETRIES) != STATUS_OK) {
+        return -1;
+    }
+    return 0;
+}
+
+/**
+ * @brief Check and clear RX error flags.
+ * @param drv USART instance.
+ * @return 0 when no error is present, -1 when an error was detected.
+ */
+static int stm32_usart_check_and_clear_rx_errors(struct usart_driver *drv)
+{
+    const uint32_t isr = usart_read32(drv, USART_ISR_OFFSET);
+
+    if ((isr & USART_ERROR_MASK) != 0UL) {
+        usart_write32(drv, USART_ICR_OFFSET, USART_ERROR_CLR);
+        return -1;
+    }
+    return 0;
+}
+
+/**
+ * @brief Configure USART line parameters.
+ * @param self USART instance.
+ * @param config Desired USART configuration.
+ * @return 0 on success, -1 on invalid parameters or hardware failure.
+ */
+static int stm32_usart_fops_configure(struct usart_driver *self,
+                                      const struct usart_config *config)
+{
+    uint32_t cr1;
+    uint32_t cr2;
+    uint32_t cr3;
+    uint32_t busfreq_mhz;
+    uint32_t brr;
+
+    if (self == NULL || config == NULL) {
+        return -1;
+    }
+
+    if (!usart_is_ready(self)) {
+        return -1;
+    }
+
+    stm32_usart_disable(self);
+
+    if (config->baudrate == 0U) {
+        return -1;
+    }
+
+    /*
+     * BRR in 16x oversampling mode: BRR = f_CK / baudrate.
+     * f_CK is retrieved through the generic Merlin platform API and is
+     * returned in MHz (as provided by generated *_dt.h metadata).
+     */
+    if (merlin_platform_driver_get_bus_clock(&self->platform, &busfreq_mhz) != STATUS_OK) {
+        return -1;
+    }
+
+    brr = (uint32_t)(((uint64_t)busfreq_mhz * 1000000ULL) / (uint64_t)config->baudrate);
+    if (brr == 0U) {
+        return -1;
+    }
+    usart_write32(self, USART_BRR_OFFSET, brr);
+
+    /* CR1: word length, parity, TX/RX enable */
+    cr1 = usart_read32(self, USART_CR1_OFFSET);
+    cr1 &= ~(USART_CR1_M0 | USART_CR1_M1 | USART_CR1_PCE | USART_CR1_PS |
+             USART_CR1_TE | USART_CR1_RE | USART_CR1_OVER8);
+
+    switch (config->word_length) {
+        case USART_WORD_LENGTH_7:
+            cr1 |= USART_CR1_M1;
+            break;
+        case USART_WORD_LENGTH_9:
+            cr1 |= USART_CR1_M0;
+            break;
+        case USART_WORD_LENGTH_8:
+        default:
+            break;
+    }
+
+    switch (config->parity) {
+        case USART_PARITY_ODD:
+            cr1 |= USART_CR1_PCE | USART_CR1_PS;
+            break;
+        case USART_PARITY_EVEN:
+            cr1 |= USART_CR1_PCE;
+            break;
+        case USART_PARITY_NONE:
+        default:
+            break;
+    }
+
+    if (config->tx_enable) {
+        cr1 |= USART_CR1_TE;
+    }
+    if (config->rx_enable) {
+        cr1 |= USART_CR1_RE;
+    }
+    usart_write32(self, USART_CR1_OFFSET, cr1);
+
+    /* CR2: stop bits, synchronous clock */
+    cr2 = usart_read32(self, USART_CR2_OFFSET);
+    cr2 &= ~(USART_CR2_STOP_MASK | USART_CR2_CLKEN);
+
+    switch (config->stop_bits) {
+        case USART_STOP_BITS_0_5:
+            cr2 |= USART_CR2_STOP_0_5;
+            break;
+        case USART_STOP_BITS_2:
+            cr2 |= USART_CR2_STOP_2;
+            break;
+        case USART_STOP_BITS_1_5:
+            cr2 |= USART_CR2_STOP_1_5;
+            break;
+        case USART_STOP_BITS_1:
+        default:
+            cr2 |= USART_CR2_STOP_1;
+            break;
+    }
+
+    if (config->mode == USART_MODE_SYNCHRONOUS) {
+        cr2 |= USART_CR2_CLKEN;
+    }
+    usart_write32(self, USART_CR2_OFFSET, cr2);
+
+    /* CR3: hardware flow control */
+    cr3 = usart_read32(self, USART_CR3_OFFSET);
+    cr3 &= ~(USART_CR3_RTSE | USART_CR3_CTSE);
+
+    switch (config->flow_control) {
+        case USART_FLOW_CONTROL_RTS:
+            cr3 |= USART_CR3_RTSE;
+            break;
+        case USART_FLOW_CONTROL_CTS:
+            cr3 |= USART_CR3_CTSE;
+            break;
+        case USART_FLOW_CONTROL_RTS_CTS:
+            cr3 |= USART_CR3_RTSE | USART_CR3_CTSE;
+            break;
+        case USART_FLOW_CONTROL_NONE:
+        default:
+            break;
+    }
+    usart_write32(self, USART_CR3_OFFSET, cr3);
+
+    stm32_usart_enable(self);
+
+    return 0;
+}
+
+/**
+ * @brief Write bytes on USART TX.
+ * @param self USART instance.
+ * @param wrbuf Buffer to transmit.
+ * @param len Number of bytes to transmit.
+ * @return 0 on success, -1 on invalid parameters or hardware failure.
+ */
+static int stm32_usart_fops_write(struct usart_driver *self,
+                                  const uint8_t *wrbuf, size_t len)
+{
+    if (self == NULL || wrbuf == NULL || len == 0U) {
+        return -1;
+    }
+
+    if (!usart_is_ready(self)) {
+        return -1;
+    }
+
+    for (size_t i = 0U; i < len; i++) {
+        if (stm32_usart_wait_txe(self) != 0) {
+            return -1;
+        }
+        merlin_iowrite8(usart_reg(self, USART_TDR_OFFSET), wrbuf[i]);
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Read bytes from USART RX.
+ * @param self USART instance.
+ * @param rdbuf Destination buffer.
+ * @param len Number of bytes to read.
+ * @return 0 on success, -1 on invalid parameters or hardware failure.
+ */
+static int stm32_usart_fops_read(struct usart_driver *self,
+                                 uint8_t *rdbuf, size_t len)
+{
+    if (self == NULL || rdbuf == NULL || len == 0U) {
+        return -1;
+    }
+
+    if (!usart_is_ready(self)) {
+        return -1;
+    }
+
+    for (size_t i = 0U; i < len; i++) {
+        if (stm32_usart_wait_rxne(self) != 0) {
+            return -1;
+        }
+        if (stm32_usart_check_and_clear_rx_errors(self) != 0) {
+            return -1;
+        }
+        rdbuf[i] = merlin_ioread8(usart_reg(self, USART_RDR_OFFSET));
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Wait until USART TX is drained.
+ * @param self USART instance.
+ * @return 0 on success, -1 on timeout or invalid state.
+ */
+static int stm32_usart_fops_flush(struct usart_driver *self)
+{
+    if (self == NULL || !usart_is_ready(self)) {
+        return -1;
+    }
+
+    if (stm32_usart_wait_tc(self) != 0) {
+        return -1;
+    }
+
+    usart_write32(self, USART_ICR_OFFSET, USART_ICR_TCCF);
+
+    return 0;
+}
+
+/**
+ * @brief ISR callback bound to the platform driver entry.
+ * @param self Pointer to struct platform_device_driver.
+ * @param IRQn Interrupt line number.
+ * @return 0 if the matching instance was found and acknowledged, -1 otherwise.
+ */
+static int stm32_usart_isr(void *self, uint32_t IRQn)
+{
+    struct platform_device_driver *pdrv = (struct platform_device_driver *)self;
+
+    (void)IRQn;
+
+    /*
+     * Resolve the owning usart_driver from the platform_device_driver
+     * pointer by scanning the instance table.
+     */
+    for (size_t i = 0U; i < STM32_USART_MAX_INSTANCES; i++) {
+        if (!g_usart_slot_used[i]) {
+            continue;
+        }
+        if (&g_usart_instances[i].platform == pdrv) {
+            struct usart_driver *drv = &g_usart_instances[i];
+
+            if (!usart_is_ready(drv)) {
+                return -1;
+            }
+            /*
+             * In polled mode the ISR only clears pending error and TC flags
+             * so that the controller does not stay stuck when an interrupt
+             * fires.  A real driver would dispatch received bytes to a ring
+             * buffer here.
+             */
+            usart_write32(drv, USART_ICR_OFFSET,
+                          USART_ERROR_CLR | USART_ICR_TCCF);
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+/**
+ * @brief Register a USART instance in Merlin.
+ * @param label DTS label of the target USART peripheral.
+ * @return 0 on success, -1 on allocation or registration failure.
+ */
+int stm32_usart_probe(uint32_t label)
+{
+    struct usart_driver *drv = stm32_usart_instance_alloc();
+
+    if (drv == NULL) {
+        return -1;
+    }
+
+    if (merlin_platform_driver_register(&drv->platform, label) != STATUS_OK) {
+        stm32_usart_instance_free(drv);
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Map and configure a registered USART instance.
+ * @param label DTS label of the target USART peripheral.
+ * @param cfg Line configuration to apply.
+ * @return 0 on success, -1 on failure.
+ */
+int stm32_usart_init(uint32_t label, const struct usart_config *cfg)
+{
+    struct usart_driver *drv = stm32_usart_instance_get(label);
+
+    if (drv == NULL || cfg == NULL) {
+        return -1;
+    }
+
+    if (merlin_platform_driver_map(&drv->platform) != STATUS_OK) {
+        return -1;
+    }
+
+    if (merlin_platform_driver_configure_gpio(&drv->platform) != STATUS_OK) {
+        return -1;
+    }
+
+    return stm32_usart_fops_configure(drv, cfg);
+}
+
+/**
+ * @brief Public write API for a specific USART instance.
+ * @param label DTS label of the target USART peripheral.
+ * @param wrbuf Buffer to transmit.
+ * @param len Number of bytes to transmit.
+ * @return 0 on success, -1 on failure.
+ */
+int stm32_usart_write(uint32_t label, const uint8_t *wrbuf, size_t len)
+{
+    struct usart_driver *drv = stm32_usart_instance_get(label);
+
+    if (drv == NULL) {
+        return -1;
+    }
+
+    return stm32_usart_fops_write(drv, wrbuf, len);
+}
+
+/**
+ * @brief Public read API for a specific USART instance.
+ * @param label DTS label of the target USART peripheral.
+ * @param rdbuf Destination buffer.
+ * @param len Number of bytes to read.
+ * @return 0 on success, -1 on failure.
+ */
+int stm32_usart_read(uint32_t label, uint8_t *rdbuf, size_t len)
+{
+    struct usart_driver *drv = stm32_usart_instance_get(label);
+
+    if (drv == NULL) {
+        return -1;
+    }
+
+    return stm32_usart_fops_read(drv, rdbuf, len);
+}
+
+/**
+ * @brief Public flush API for a specific USART instance.
+ * @param label DTS label of the target USART peripheral.
+ * @return 0 on success, -1 on failure.
+ */
+int stm32_usart_flush(uint32_t label)
+{
+    struct usart_driver *drv = stm32_usart_instance_get(label);
+
+    if (drv == NULL) {
+        return -1;
+    }
+
+    return stm32_usart_fops_flush(drv);
+}
+
+/**
+ * @brief Acknowledge an IRQ across active USART instances.
+ * @param IRQn Interrupt line number.
+ */
+void stm32_usart_acknowledge_irq(uint32_t IRQn)
+{
+    /*
+     * Scan all active instances and forward the acknowledge to each one.
+     * merlin_platform_driver_irq_dispatch() handles the routing generically;
+     * this function lets a task explicitly acknowledge for a known IRQn.
+     */
+    for (size_t i = 0U; i < STM32_USART_MAX_INSTANCES; i++) {
+        if (g_usart_slot_used[i]) {
+            (void)merlin_platform_acknowledge_irq(
+                &g_usart_instances[i].platform, IRQn);
+        }
+    }
+}
+
+/**
+ * @brief Disable and unmap a USART instance, then free its slot.
+ * @param label DTS label of the target USART peripheral.
+ * @return 0 on success, -1 on failure.
+ */
+int stm32_usart_release(uint32_t label)
+{
+    struct usart_driver *drv = stm32_usart_instance_get(label);
+
+    if (drv == NULL) {
+        return -1;
+    }
+
+    stm32_usart_disable(drv);
+
+    if (merlin_platform_driver_unmap(&drv->platform) != STATUS_OK) {
+        return -1;
+    }
+
+    stm32_usart_instance_free(drv);
+
+    return 0;
+}

--- a/examples/usart/stm32_usart_driver.c
+++ b/examples/usart/stm32_usart_driver.c
@@ -507,6 +507,33 @@ static int stm32_usart_fops_flush(struct usart_driver *self)
 
 /**
  * @brief ISR callback bound to the platform driver entry.
+ *
+ * Note that this function is not directly called by the application but instead automatically invoked
+ * by the Merlin platform when an interrupt is received on an IRQ line associated to a registered USART instance.
+ *
+ * This is done through a typical:
+ *
+ * ```
+ * while (true) {
+ *    // blocking wait for an interrupt event
+ *    res = sys_waitforevent(EVENT_INTERRUPT, 0);
+ *    if (res == STATUS_OK) {
+ *       // IRQ received, get back irq_info struct and call merlin to dipatch the IRQ to the right driver instance
+ *       copy_from_kernel(&mybuf, sizeof(mybuf));
+ *       IRQn = mybuf.data[0];
+ *       // request merlin dispatch, that call this function automatically and acknowledge the IRQ at controller level
+ *       // once this ISR is executed
+ *       merlin_platform_driver_irq_displatch(received_IRQn);
+ *       usart_get_char(&mychar);
+ *       // process mychar the way you want here
+ *    }
+ * }
+ * ```
+ *
+ * This very simple driver is configured in polled mode, so the ISR only serves to clear pending error and TC flags
+ * when an interrupt fires, preventing the controller from getting stuck.
+ * A real driver would dispatch received bytes to a ring buffer here, rising a data_receive flag to upper layers.
+ *
  * @param self Pointer to struct platform_device_driver.
  * @param IRQn Interrupt line number.
  * @return 0 if the matching instance was found and acknowledged, -1 otherwise.
@@ -539,6 +566,7 @@ static int stm32_usart_isr(void *self, uint32_t IRQn)
              */
             usart_write32(drv, USART_ICR_OFFSET,
                           USART_ERROR_CLR | USART_ICR_TCCF);
+
             return 0;
         }
     }
@@ -642,25 +670,6 @@ int stm32_usart_flush(uint32_t label)
     }
 
     return stm32_usart_fops_flush(drv);
-}
-
-/**
- * @brief Acknowledge an IRQ across active USART instances.
- * @param IRQn Interrupt line number.
- */
-void stm32_usart_acknowledge_irq(uint32_t IRQn)
-{
-    /*
-     * Scan all active instances and forward the acknowledge to each one.
-     * merlin_platform_driver_irq_dispatch() handles the routing generically;
-     * this function lets a task explicitly acknowledge for a known IRQn.
-     */
-    for (size_t i = 0U; i < STM32_USART_MAX_INSTANCES; i++) {
-        if (g_usart_slot_used[i]) {
-            (void)merlin_platform_acknowledge_irq(
-                &g_usart_instances[i].platform, IRQn);
-        }
-    }
 }
 
 /**

--- a/examples/usart/stm32_usart_driver.h
+++ b/examples/usart/stm32_usart_driver.h
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 H2Lab Development Team
+
+#ifndef STM32_USART_DRIVER_H
+#define STM32_USART_DRIVER_H
+
+#include <inttypes.h>
+#include <merlin/buses/usart.h>
+
+/**
+ * Maximum number of USART/UART instances this driver can manage
+ * simultaneously.  Increase as needed for targets with more serial
+ * controllers.
+ */
+#define STM32_USART_MAX_INSTANCES 4U
+
+/**
+ * @brief Probe a STM32 USART/UART controller.
+ *
+ * Registers the driver instance into Merlin using the DTS label that
+ * uniquely identifies the controller peripheral.  This only performs
+ * registration; the device is neither mapped nor initialised at this
+ * stage.
+ *
+ * This driver is compatible with the USART IP block shared across the
+ * STM32 product families (F0/F1/F2/F3/F4/F7/G0/G4/H5/H7/L0/L4/U5/WB…).
+ *
+ * @param label sentry,label value as declared in the DTS node
+ *
+ * @return 0 on success, -1 if no free instance slot is available or
+ *         if the DTS registration fails
+ */
+int stm32_usart_probe(uint32_t label);
+
+/**
+ * @brief Initialise a STM32 USART/UART controller.
+ *
+ * Maps the device into the caller address space, configures the associated
+ * GPIOs (TX/RX and optional CTS/RTS pins) and programs the line parameters.
+ * Must be called after a successful stm32_usart_probe().
+ *
+ * @param label DTS label identifying the controller instance
+ * @param cfg   line configuration (baudrate, parity, stop bits, …)
+ *
+ * @return 0 on success, -1 on failure
+ */
+int stm32_usart_init(uint32_t label, const struct usart_config *cfg);
+
+/**
+ * @brief Transmit a byte buffer over a USART/UART TX path.
+ *
+ * Blocking, polled write.  Each byte is sent only after the previous one
+ * has been accepted by the transmit data register.
+ *
+ * @param label DTS label identifying the controller instance
+ * @param wrbuf bytes to transmit
+ * @param len   number of bytes to transmit
+ *
+ * @return 0 on success, -1 on failure
+ */
+int stm32_usart_write(uint32_t label, const uint8_t *wrbuf, size_t len);
+
+/**
+ * @brief Receive bytes from a USART/UART RX path.
+ *
+ * Blocking, polled read.  The function waits for each byte to arrive in
+ * the receive data register before advancing.
+ *
+ * @param label DTS label identifying the controller instance
+ * @param rdbuf buffer used to store received bytes
+ * @param len   number of bytes to receive
+ *
+ * @return 0 on success, -1 on failure
+ */
+int stm32_usart_read(uint32_t label, uint8_t *rdbuf, size_t len);
+
+/**
+ * @brief Wait for all pending TX data to be shifted out.
+ *
+ * Polls the Transmission Complete flag until it is set or the retry
+ * counter expires.
+ *
+ * @param label DTS label identifying the controller instance
+ *
+ * @return 0 on success, -1 if the TC flag was not set in time
+ */
+int stm32_usart_flush(uint32_t label);
+
+/**
+ * @brief Acknowledge a USART/UART controller interrupt.
+ *
+ * Called from the application wait-for-event loop when EVENT_INTERRUPT is
+ * received.  The correct instance is resolved from the IRQ number.
+ *
+ * @param IRQn interrupt number received from the kernel
+ */
+void stm32_usart_acknowledge_irq(uint32_t IRQn);
+
+/**
+ * @brief Release a USART/UART controller.
+ *
+ * Disables the controller, unmaps the device from the caller address
+ * space and frees the instance slot so it can be re-probed.
+ *
+ * @param label DTS label identifying the controller instance
+ *
+ * @return 0 on success, -1 on failure
+ */
+int stm32_usart_release(uint32_t label);
+
+#endif /* STM32_USART_DRIVER_H */

--- a/examples/usb/usbotgfs_driver.c
+++ b/examples/usb/usbotgfs_driver.c
@@ -706,11 +706,6 @@ static int usbotgfs_isr(void *self, uint32_t IRQn)
     if (clear_mask != 0UL) {
         usbotgfs_write32(USB_GINTSTS_OFFSET, clear_mask);
     }
-
-    if (merlin_platform_acknowledge_irq(&g_usbotgfs_driver, IRQn) != STATUS_OK) {
-        return -1;
-    }
-
     return 0;
 }
 

--- a/include/merlin/buses/usart.h
+++ b/include/merlin/buses/usart.h
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 H2Lab Development Team
+
+#ifndef MERLIN_ARCH_USART_H
+#define MERLIN_ARCH_USART_H
+
+#include <types.h>
+#include <merlin/platform/driver.h>
+
+/**
+ * @brief Serial controller operating modes supported by the unified UART/USART API.
+ *
+ * A pure UART controller typically supports only asynchronous mode, while a USART
+ * controller can additionally expose synchronous transfers. This enum provides a
+ * single abstraction to describe both controller families.
+ */
+enum usart_operation_mode {
+	USART_MODE_ASYNCHRONOUS,
+	USART_MODE_SYNCHRONOUS,
+	USART_MODE_UNKNOWN,
+};
+
+/**
+ * @brief Serial parity modes.
+ */
+enum usart_parity {
+	USART_PARITY_NONE,
+	USART_PARITY_EVEN,
+	USART_PARITY_ODD,
+	USART_PARITY_UNKNOWN,
+};
+
+/**
+ * @brief Serial stop-bit configurations.
+ */
+enum usart_stop_bits {
+	USART_STOP_BITS_1,
+	USART_STOP_BITS_0_5,
+	USART_STOP_BITS_2,
+	USART_STOP_BITS_1_5,
+	USART_STOP_BITS_UNKNOWN,
+};
+
+/**
+ * @brief Serial word-length configurations.
+ */
+enum usart_word_length {
+	USART_WORD_LENGTH_7,
+	USART_WORD_LENGTH_8,
+	USART_WORD_LENGTH_9,
+	USART_WORD_LENGTH_UNKNOWN,
+};
+
+/**
+ * @brief Hardware flow-control modes.
+ */
+enum usart_flow_control {
+	USART_FLOW_CONTROL_NONE,
+	USART_FLOW_CONTROL_RTS,
+	USART_FLOW_CONTROL_CTS,
+	USART_FLOW_CONTROL_RTS_CTS,
+	USART_FLOW_CONTROL_UNKNOWN,
+};
+
+/**
+ * @brief Unified line configuration for UART and USART controllers.
+ *
+ * The backend DTS integration can later use this structure to expose the
+ * controller capabilities and default parameters in a common way.
+ *
+ */
+struct usart_config {
+	uint32_t baudrate;
+	enum usart_operation_mode mode;
+	enum usart_parity parity;
+	enum usart_stop_bits stop_bits;
+	enum usart_word_length word_length;
+	enum usart_flow_control flow_control;
+	bool tx_enable;
+	bool rx_enable;
+};
+
+/** USART driver structure pre-declaration */
+struct usart_driver;
+
+/**
+ * @brief Configure the serial controller line parameters.
+ *
+ * @param self pointer to the usart_driver structure
+ * @param config unified UART/USART line configuration
+ *
+ * @return 0 on success, negative error code on failure
+ */
+typedef int (*usart_configure_fn_t)(struct usart_driver *self, const struct usart_config *config);
+
+/**
+ * @brief Write bytes to the controller transmit path.
+ *
+ * @param self pointer to the usart_driver structure
+ * @param wrbuf buffer containing bytes to transmit
+ * @param len number of bytes to transmit
+ *
+ * @return 0 on success, negative error code on failure
+ */
+typedef int (*usart_write_fn_t)(struct usart_driver *self, const uint8_t *wrbuf, size_t len);
+
+/**
+ * @brief Read bytes from the controller receive path.
+ *
+ * @param self pointer to the usart_driver structure
+ * @param rdbuf buffer used to store received bytes
+ * @param len maximum number of bytes to receive
+ *
+ * @return 0 on success, negative error code on failure
+ */
+typedef int (*usart_read_fn_t)(struct usart_driver *self, uint8_t *rdbuf, size_t len);
+
+/**
+ * @brief Flush pending transmit data if the controller provides such an operation.
+ *
+ * @param self pointer to the usart_driver structure
+ *
+ * @return 0 on success, negative error code on failure
+ */
+typedef int (*usart_flush_fn_t)(struct usart_driver *self);
+
+/**
+ * @brief USART/UART specific operations exposed to Merlin.
+ *
+ * These callbacks describe the minimum common contract expected from a serial
+ * controller driver registered in Merlin.
+ */
+struct usart_bus_fops {
+	usart_configure_fn_t configure;
+	usart_write_fn_t write;
+	usart_read_fn_t read;
+	usart_flush_fn_t flush;
+};
+
+/**
+ * @brief Unified UART/USART controller descriptor registered in Merlin.
+ *
+ * This structure does not implement the driver logic itself. It only binds the
+ * serial-specific operations to the generic Merlin platform registration layer.
+ */
+struct usart_driver {
+	struct usart_bus_fops *fops;
+	struct platform_device_driver platform;
+	void *private_data;
+};
+
+#endif/*!MERLIN_ARCH_USART_H*/

--- a/include/merlin/platform/driver.h
+++ b/include/merlin/platform/driver.h
@@ -114,13 +114,13 @@ Status merlin_platform_driver_unmap(struct platform_device_driver *self);
  * This function aim to be used in the wait_for_event() Sentry UAPI when EVENT_INTERRUPT is received.
  * As Merlin knows all device drivers and associated device IRQ identifier, it can properly call the
  * corresponding driver interrupt service routine based on the previously registered drivers metadata.
+ * The driver ISR is responsible for acknowledging the IRQ at device level, and then
+ * merlin_platform_driver_irq_displatch() will acknowledge the IRQ at interrupt controller level.
  *
  * This function allows a task to manipulate multiple device drivers for multiple devices without the
  * need for knowing each device interrupt identifier.
  */
 Status merlin_platform_driver_irq_displatch(uint32_t IRQn);
-
-Status merlin_platform_acknowledge_irq(struct platform_device_driver *self, uint32_t IRQn);
 
 /**
  * @brief Enable IRQs for a given device

--- a/include/merlin/platform/driver.h
+++ b/include/merlin/platform/driver.h
@@ -131,6 +131,22 @@ Status merlin_platform_acknowledge_irq(struct platform_device_driver *self, uint
  */
 Status merlin_platform_driver_configure_gpio(struct platform_device_driver *self);
 
+/**
+ * @brief get bus input clock frequency for a platform bus controller
+ *
+ * This function provides a generic interface to retrieve the parent bus input
+ * clock frequency as exported by the DTS backend for the given platform driver.
+ * The returned value is expressed in MHz and can be used by bus controller
+ * drivers to derive their prescaler / divider register configuration.
+ *
+ * @param drv pointer to the platform_device_driver structure
+ * @param busfreq_mhz pointer to output bus frequency in MHz
+ *
+ * @return STATUS_OK on success, STATUS_INVALID when the device type is not
+ * supported or arguments are invalid
+ */
+Status merlin_platform_driver_get_bus_clock(struct platform_device_driver *drv, uint32_t *busfreq_mhz);
+
 
 /**
  * @brief get the parent bus label for a given external device using its label

--- a/include/merlin/platform/driver.h
+++ b/include/merlin/platform/driver.h
@@ -123,6 +123,20 @@ Status merlin_platform_driver_irq_displatch(uint32_t IRQn);
 Status merlin_platform_acknowledge_irq(struct platform_device_driver *self, uint32_t IRQn);
 
 /**
+ * @brief Enable IRQs for a given device
+ * @param self device driver metadata
+ * @return STATUS_OK if the IRQs were successfully enabled, or other status codes depending on the error
+ */
+Status merlin_platform_driver_enable_irqs(struct platform_device_driver *self);
+
+/**
+ * @brief Disable IRQs for a given device
+ * @param self device driver metadata
+ * @return STATUS_OK if the IRQs were successfully disabled, or other status codes depending on the error
+ */
+Status merlin_platform_driver_disable_irqs(struct platform_device_driver *self);
+
+/**
  * @brief configure the driver's target device associted GPIO, when there are some
  *
  * This function use the dts-declared pinmux informations in order to configure the GPIO controller

--- a/include/meson.build
+++ b/include/meson.build
@@ -8,6 +8,7 @@ merlin_headers = files(
     'merlin/buses/spi.h',
     'merlin/buses/i2c.h',
     'merlin/buses/usb.h',
+    'merlin/buses/usart.h',
     'merlin/arch/asm-cortex-m/io.h',
     'merlin/arch/asm-rv32/io.h',
     'merlin/arch/asm-generic/io.h',

--- a/src/buses/meson.build
+++ b/src/buses/meson.build
@@ -4,3 +4,4 @@
 subdir('i2c')
 subdir('usb')
 subdir('spi')
+subdir('usart')

--- a/src/buses/usart/meson.build
+++ b/src/buses/usart/meson.build
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 H2Lab Development Team
+
+merlin_common_src += files(
+    'usart.c',
+)
+merlin_private_headers += files(
+    'usart.h',
+)
+
+usart_dt_h_template = meson.current_source_dir() / 'usart_dt.h.in'
+
+usart_dt_h = custom_target('gen_usart_dt_h',
+    input: usart_dt_h_template,
+    env: {
+        'CONFIG_TASK_LABEL': kconfig_data.get('CONFIG_TASK_LABEL', '0x0'),
+    },
+    output: '@BASENAME@',
+    command: [ dts2src, '-d', dts.full_path() , '-t', '@INPUT@', '@OUTPUT@' ],
+    depends: [ dts ],
+)
+
+generated_private_headers += [ usart_dt_h ]

--- a/src/buses/usart/usart.c
+++ b/src/buses/usart/usart.c
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 H2Lab Development Team
+
+#include <types.h>
+#include <merlin/platform/driver.h>
+#include "usart_dt.h"
+#include "usart.h"
+
+
+
+Status merlin_platform_dts_usart_get_devinfo(uint32_t devlabel, const devinfo_t **devinfo)
+{
+    Status status = STATUS_NO_ENTITY;
+#if DEV_ID_USART_MAX > 0
+    for (size_t i = 0; i < DEV_ID_USART_MAX; i++) {
+        if (usart_devices[i].devinfo.id == devlabel) {
+            *devinfo = &usart_devices[i].devinfo;
+            status = STATUS_OK;
+        }
+    }
+#endif
+    return status;
+}
+
+/**
+ * @brief get the USART bus controller pre-scaler divider value for the desired USART speed mode
+ *
+ * This function is used to retrieve the pre-scaler divider value that need to be set in
+ * the USART bus controller. Note that this value is the mathematical divider value, not the
+ * actual value to be set in the register, which can be different depending on the USART bus controller.
+ * This function is typically used in the USART bus controller initialization routine, to configure the
+ * bus controller to operate at the desired speed.
+ */
+Status merlin_usart_get_precaler_div(struct platform_device_driver *drv, uint32_t *precaler_div)
+{
+    Status status = STATUS_INVALID;
+    if (unlikely(drv == NULL || precaler_div == NULL)) {
+        return STATUS_INVALID;
+    }
+#if DEV_ID_USART_MAX > 0
+    for (size_t i = 0; i < DEV_ID_USART_MAX; i++) {
+        if (drv->label == usart_devices[i].devinfo.id) {
+            /* Note that the actual pre-scaler divider value to be set in the register can be different depending on the USART bus controller, and thus need to be calculated in the driver implementation based on the mathematical divider value */
+            *precaler_div = usart_devices[i].bus_input_clock_freq;
+            status = STATUS_OK;
+            goto end;
+        }
+    }
+end:
+#endif
+    return status;
+}

--- a/src/buses/usart/usart.h
+++ b/src/buses/usart/usart.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 H2Lab Development Team
+
+#ifndef MERLIN_PRIV_USART_H
+#define MERLIN_PRIV_USART_H
+
+#include <device.h>
+#include <inttypes.h>
+#include <merlin/platform/driver.h>
+#include <merlin/helpers.h>
+
+Status merlin_platform_dts_usart_get_devinfo(uint32_t devlabel, const devinfo_t **devinfo);
+
+Status merlin_usart_get_precaler_div(struct platform_device_driver *drv, uint32_t *precaler_div);
+
+
+#endif/* MERLIN_PRIV_USART_H */

--- a/src/buses/usart/usart_dt.h.in
+++ b/src/buses/usart/usart_dt.h.in
@@ -1,0 +1,139 @@
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 H2Lab Development Team
+
+#ifndef USART_DT_H
+#define USART_DT_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <device.h>
+
+struct usart_device_info {
+    devinfo_t devinfo;
+    uint32_t bus_input_clock_freq;
+};
+
+{% macro seq_get(value, index, default=0) -%}
+{%- if value is number -%}
+{{- value if index == 0 else default -}}
+{%- elif value and (value|length > index) -%}
+{{- value[index] -}}
+{%- else -%}
+{{- default -}}
+{%- endif -%}
+{% endmacro -%}
+
+
+{% set ns = namespace() -%}
+{% set ns.total_devices=0 -%}
+{% set ns.current_device_index=0 -%}
+
+{% set ns = namespace() -%}
+{% for device in dts.get_active_nodes() -%}
+{% if device is not owned or device is not enabled -%}
+{% continue -%}
+{% endif -%}
+{% if device is not owned_by(env.CONFIG_TASK_LABEL|int(base=16)) -%}
+{% continue -%}
+{% endif -%}
+{% endfor -%}
+
+static const struct usart_device_info usart_devices[] = {
+    {% set ns.total_devices=0 -%}
+    {% for device in dts.get_active_nodes() -%}
+    {% if device is not owned or device is not enabled -%}
+    {% continue -%}
+    {% endif -%}
+    {% if device is not owned_by(env.CONFIG_TASK_LABEL|int(base=16)) -%}
+    {% continue -%}
+    {% endif -%}
+    {% if "USART" in "%s"|format(device.label.upper()) -%}
+    {% set ns.current_device_index = ns.total_devices -%}
+    {% set ns.total_devices = ns.total_devices + 1 -%}
+    {
+        .devinfo = {
+            {% set label = device['sentry,label'] -%}
+            .id = {{ "0x%xUL"|format(label) }},
+            {% if device.reg -%}
+            .baseaddr = {{ "0x%08x"|format(device.reg[0]) }},
+            .size = {{ "0x%08x"|format(device.reg[1]) }},
+            {% else -%}
+            .baseaddr = 0UL,
+            .size = 0UL,
+            {% endif -%}
+            {% if device.interrupts -%}
+            .num_interrupt = 1,
+            .its = {
+                {% if device.interrupts[0] -%}
+                {  .it_controler = {{ device.interrupts[1] }}UL, .it_num = {{ device.interrupts[0] }}UL },
+                {% else -%}
+                {  .it_controler = 0UL, .it_num = 0UL },
+                {% endif -%}
+                {% for irq in [ 1,2,3,4,5,6,7] -%}
+                {  .it_controler = 0UL, .it_num = 0UL },
+                {% endfor -%}
+            },
+            {% else -%}
+            .num_interrupt = 0,
+            .its = {
+                {% for irq in [ 0,1,2,3,4,5,6,7] -%}
+                {  .it_controler = 0UL, .it_num = 0UL },
+                {% endfor -%}
+            },
+            {% endif -%}
+            {% if device['pinctrl-0'] -%}
+            {% set numio = device['pinctrl-0']|length %}
+            .num_ios = {{ numio }},
+            .ios = {
+                {% for io in [ 0,1,2,3,4,5,6,7] -%}
+                {% if io < numio -%}
+                {% set iodata = device['pinctrl-0'][io] -%}
+                {
+                    {#
+                     the GPIO port id is numeric here, using the same resolution
+                     as the GPIO driver device tree forge (see stm32-gpio-dt.h for e.g.
+                    -#}
+                    {% set ns.io_gpio_port=0 -%}
+                    /* FIXME: adding dts primitive in devicetree to get back 'gpio_controller' label to get gpios in a portbable way */
+                    {% set gpio_ports = dts.get_compatible("st,stm32-gpio") -%}
+                    {% for port in gpio_ports -%}
+                    {% if port.status and port.status == "okay" -%}
+                    {% if port.label == iodata.pinmux[0].label -%}
+                    #define {{ "%s"|format(iodata.id.upper()) }} (dev_io_t*)&i2c_devices[{{ ns.current_device_index }}].devinfo.ios[{{ io }}]
+                    /* using port {{ port.label.upper() }} for {{ iodata.id }} */
+                    .port = {{ ns.io_gpio_port }},
+                    {% endif -%}
+                    {% set ns.io_gpio_port = ns.io_gpio_port + 1 -%}
+                    {% endif -%}
+                    {% endfor -%}
+                    .pin = {{ seq_get(iodata.pinmux, 1) }},
+                    .mode = {{ seq_get(iodata.pinmux, 2) }},
+                    .af = {{ seq_get(iodata.pinmux, 3) }},
+                    .ppull = {{ seq_get(iodata.pincfg, 0) }},
+                    .speed = {{ seq_get(iodata.pincfg, 1) }},
+                    .pupdr = {{ seq_get(iodata.pincfg, 2) }},
+                },
+                {% else -%}
+                { .port = 0, .pin = 0, .mode = 0, .af = 0, .ppull = 0, .speed = 0, .pupdr = 0, },
+                {% endif -%}
+                {% endfor -%}
+            },
+            {% else -%}
+            .num_ios = 0,
+            .ios = {
+                {% for io in [0,1,2,3,4,5,6,7] -%}
+                { .port = 0, .pin = 0, .mode = 0, .af = 0, .ppull = 0, .speed = 0, .pupdr = 0, },
+                {% endfor -%}
+            },
+            {% endif -%}
+        },
+        .bus_input_clock_freq = {{ "%uUL"|format(seq_get(device['usart,peripheral-clock'], 0, 0)|int) }},
+    },
+    {% endif -%}
+    {% endfor %}
+};
+
+#define DEV_ID_USART_MAX {{ "0x%xUL"|format(ns.total_devices) }}
+
+#endif

--- a/src/platform/platform_driver.c
+++ b/src/platform/platform_driver.c
@@ -104,7 +104,7 @@ end:
     return res;
 }
 
-Status merlin_platform_get_driver_from_irq(uint32_t IRQn, struct platform_device_driver **drv)
+static Status merlin_platform_get_driver_from_irq(uint32_t IRQn, struct platform_device_driver **drv)
 {
     Status res = STATUS_NO_ENTITY;
     if (unlikely(drv == NULL)) {
@@ -123,6 +123,30 @@ Status merlin_platform_get_driver_from_irq(uint32_t IRQn, struct platform_device
 end:
     return res;
 }
+
+static Status merlin_platform_acknowledge_irq(struct platform_device_driver *self, uint32_t IRQn)
+{
+    Status res = STATUS_NO_ENTITY;
+    for (size_t i = 0; i < self->devinfo->num_interrupt; i++) {
+        if (self->devinfo->its[i].it_num == IRQn) {
+            /* first clear pending IRQ at NVIC level. Note that the driver must already have
+             * cleared the interrupt at the peripheral level
+             */
+            res = __sys_irq_acknowledge(self->devinfo->its[i].it_num);
+            if (unlikely(res != STATUS_OK)) {
+                goto err;
+            }
+            /* re-enable IRQ at NVIC level if needed */
+            res = __sys_irq_enable(self->devinfo->its[i].it_num);
+            if (unlikely(res != STATUS_OK)) {
+                goto err;
+            }
+        }
+    }
+err:
+    return res;
+}
+
 
 static Status merlin_platform_get_from_handle(devh_t handle, struct platform_device_driver **drv)
 {
@@ -161,19 +185,18 @@ Status merlin_platform_driver_unmap(struct platform_device_driver *self)
 }
 
 
-/* resolve driver context in the registered driver(s) for given IRQn using DTS backend,
+/*
+ * resolve driver context in the registered driver(s) for given IRQn using DTS backend,
  * and call the fops->isr routine for it.
  * Minimalist model, to auto-dispatch IRQ events received from sys_get_event()
  */
 Status merlin_platform_driver_irq_displatch(uint32_t IRQn)
 {
-    struct platform_device_driver *platform_device_driver;
-    if (unlikely(merlin_platform_get_driver_from_irq(IRQn, &platform_device_driver) != STATUS_OK)) {
-        return STATUS_INVALID;
-    }
-    struct platform_device_driver *self;
-    if (unlikely(merlin_platform_get_from_handle(platform_device_driver->devh, &self) != STATUS_OK)) {
-        return STATUS_INVALID;
+    struct platform_device_driver *self = NULL;
+    Status res = STATUS_NO_ENTITY;
+    if (unlikely(merlin_platform_get_driver_from_irq(IRQn, &self) != STATUS_OK)) {
+        res = STATUS_INVALID;
+	goto end;
     }
     /* calling device driver interrupt service routine */
     /* acknowledge IRQ at device level using driver ISR */
@@ -182,6 +205,9 @@ Status merlin_platform_driver_irq_displatch(uint32_t IRQn)
     }
     /* acknowledge IRQ at interrupt controller level */
     merlin_platform_acknowledge_irq(self, IRQn);
+    res = STATUS_OK;
+end:
+    return res;
 }
 
 
@@ -327,15 +353,4 @@ Status merlin_platform_driver_get_bus_clock(struct platform_device_driver *drv, 
         default:
             return STATUS_INVALID;
     }
-}
-
-Status merlin_platform_acknowledge_irq(struct platform_device_driver *self, uint32_t IRQn)
-{
-    Status res = STATUS_NO_ENTITY;
-    for (size_t i = 0; i < self->devinfo->num_interrupt; i++) {
-        if (self->devinfo->its[i].it_num == IRQn) {
-            res = __sys_irq_acknowledge(self->devinfo->its[i].it_num);
-        }
-    }
-    return res;
 }

--- a/src/platform/platform_driver.c
+++ b/src/platform/platform_driver.c
@@ -8,6 +8,7 @@
 #include <merlin/helpers.h>
 #include "../buses/i2c/i2c.h"
 #include "../buses/usb/usb.h"
+#include "../buses/usart/usart.h"
 
 /* Note that Sentry tasks are monothreaded and thus do not require locks or concurrency check ath Merlin level */
 static struct platform_device_driver *registered_drivers[CONFIG_MAX_REGISTERED_DRIVERS];
@@ -215,6 +216,11 @@ Status merlin_platform_driver_register(struct platform_device_driver *driver, ui
                 return STATUS_INVALID;
             }
             break;
+        case DEVICE_TYPE_USART:
+            if (unlikely(merlin_platform_dts_usart_get_devinfo(label, &devinfo) != STATUS_OK)) {
+                return STATUS_INVALID;
+            }
+            break;
         default:
             return STATUS_INVALID;
     }
@@ -254,6 +260,22 @@ Status merlin_platform_driver_configure_gpio(struct platform_device_driver *self
     }
 end:
     return status;
+}
+
+Status merlin_platform_driver_get_bus_clock(struct platform_device_driver *drv, uint32_t *busfreq_mhz)
+{
+    if (unlikely(drv == NULL || busfreq_mhz == NULL)) {
+        return STATUS_INVALID;
+    }
+
+    switch (drv->type) {
+        case DEVICE_TYPE_I2C:
+            return merlin_i2c_get_precaler_div(drv, busfreq_mhz);
+        case DEVICE_TYPE_USART:
+            return merlin_usart_get_precaler_div(drv, busfreq_mhz);
+        default:
+            return STATUS_INVALID;
+    }
 }
 
 Status merlin_platform_acknowledge_irq(struct platform_device_driver *self, uint32_t IRQn)

--- a/src/platform/platform_driver.c
+++ b/src/platform/platform_driver.c
@@ -262,6 +262,52 @@ end:
     return status;
 }
 
+Status merlin_platform_driver_enable_irqs(struct platform_device_driver *self)
+{
+	Status status = STATUS_INVALID;
+    const devinfo_t *devinfo = NULL;
+    if (unlikely(self == NULL)) {
+        goto end;
+    }
+    devinfo = self->devinfo;
+    if (unlikely(devinfo == NULL)) {
+         goto end;
+    }
+    /* if no IRQ to enable, set to NOENT */
+    status = STATUS_NO_ENTITY;
+    for (size_t i = 0; i < devinfo->num_interrupt; i++) {
+        status = __sys_irq_enable(devinfo->its[i].it_num);
+        if (unlikely(status != STATUS_OK)) {
+            goto end;
+        }
+    }
+end:
+    return status;
+}
+
+Status merlin_platform_driver_disable_irqs(struct platform_device_driver *self)
+{
+	Status status = STATUS_INVALID;
+    const devinfo_t *devinfo = NULL;
+    if (unlikely(self == NULL)) {
+        goto end;
+    }
+    devinfo = self->devinfo;
+    if (unlikely(devinfo == NULL)) {
+         goto end;
+    }
+    /* if no IRQ to disable, set to NOENT */
+    status = STATUS_NO_ENTITY;
+    for (size_t i = 0; i < devinfo->num_interrupt; i++) {
+        status = __sys_irq_disable(devinfo->its[i].it_num);
+        if (unlikely(status != STATUS_OK)) {
+            goto end;
+        }
+    }
+end:
+    return status;
+}
+
 Status merlin_platform_driver_get_bus_clock(struct platform_device_driver *drv, uint32_t *busfreq_mhz)
 {
     if (unlikely(drv == NULL || busfreq_mhz == NULL)) {

--- a/src/platform/platform_driver.c
+++ b/src/platform/platform_driver.c
@@ -176,7 +176,12 @@ Status merlin_platform_driver_irq_displatch(uint32_t IRQn)
         return STATUS_INVALID;
     }
     /* calling device driver interrupt service routine */
-    return self->platform_fops.isr(self, IRQn);
+    /* acknowledge IRQ at device level using driver ISR */
+    if (self->platform_fops.isr != NULL) {
+        self->platform_fops.isr(self, IRQn);
+    }
+    /* acknowledge IRQ at interrupt controller level */
+    merlin_platform_acknowledge_irq(self, IRQn);
 }
 
 


### PR DESCRIPTION
Adding support for serial drivers in both poll & interrupt mode.
Fixing the way ISR dispatching is made to let the ISR automatically handle the driver-declared interrupt routine and interrupt global controller acknowledging on success.

This simplify, in a generic way, interrupt-based device drivers. through ISR auto dispatch.

A typical IT-based event management has been validated with  such an event loop with a merlin-based usart driver. 

**Note that neither the application nor the driver manipulate any DTS-related or hard-coded values other than the device label**

```c
    uint8_t rx_char;
    const struct usart_config uart3_cfg = {
        .baudrate     = 115200U,
        .mode         = USART_MODE_ASYNCHRONOUS,
        .parity       = USART_PARITY_NONE,
        .stop_bits    = USART_STOP_BITS_1,
        .word_length  = USART_WORD_LENGTH_8,
        .flow_control = USART_FLOW_CONTROL_NONE,
        .tx_enable    = true,
        .rx_enable    = true,
    };

    if (stm32_usart_probe(USART3_LABEL) != 0) {
        goto err;
    }

    if (stm32_usart_init(USART3_LABEL, &uart3_cfg) != 0) {
        goto err;
    }
   // [...]

    for (;;) {
        /* kernel input event buffer local copy */
        uint8_t event_buf[SENTRY_SVCEXCHANGE_LEN];
        exchange_event_t *event = (exchange_event_t *)event_buf;
        /* received IRQs table field addr in buffer */
        uint32_t *IRQn = (uint32_t *)(&event->data[0]);

        /* wait for event (preemptive) for at most 20ms */
        if (__sys_wait_for_event(EVENT_TYPE_IRQ, 20) != STATUS_OK) {
            /* nothing received, yield CPU, other policy may be defined if needed (timeout...) */
            __sys_sched_yield();
            continue;
        }
        /* get back IRQ event from kernel */
        copy_from_kernel(event_buf, SENTRY_SVCEXCHANGE_LEN);

        /*
         * here we only wait for IRQ, so that we do not need to check the event type */
         *
         * Sentry kernel allows to receive multiple IRQs in a single event from the same source (IRQ buffering),
         * so we iterate over each IRQ in the event and dispatch it. For an USART mode, there should have only
         * one IRQ at a time
         */
        for (uint8_t num_irqs = 0; num_irqs < event->length / sizeof(uint32_t); num_irqs++) {
            merlin_platform_driver_irq_displatch(IRQn[num_irqs]);
        }

        /* using usart device driver private_data fulfilled by the ISR called through dispatch, as in IT mode for RX */
        if (stm32_usart_read(USART3_LABEL, &rx_char) != 0) {
            continue;
        }
       /* do whatever we want with this char */
       // [...]
    }
```
